### PR TITLE
Changed group chat check to match errbot 5.0

### DIFF
--- a/LinkParser/linkparser.py
+++ b/LinkParser/linkparser.py
@@ -10,7 +10,7 @@ class LinkParser(BotPlugin):
     @re_botcmd(prefixed=False, flags=re.IGNORECASE, pattern='(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)')
     def url_match(self, msg, match):
         # skip if in groupchat to circumvent parsing loop
-        if msg.type == 'groupchat':
+        if msg.is_group:
             if msg.frm.client == self.bot_config.CHATROOM_FN:
                 return
         url = match.groups()[0]


### PR DESCRIPTION
Use `is_group` instead of comparison on `type`, as the latter has been removed with errbot 5.0.
According to the [docs][MessageDocs], this is backwards compatible to at least errbot 4.2

[MessageDocs]: http://errbot.io/en/4.2/errbot.backends.base.html#errbot.backends.base.Message